### PR TITLE
Lockdown cf version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ jobs:
     steps:
       ...
       - name: Deploying carbon-custom-elements storybook to IBM Cloud
-        uses: carbon-design-system/action-ibmcloud-cf@v1.1.0
+        uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
         with:
           cloud-api-key: ${{ secrets.THE_SECRET_OF_CF_TOKEN }}
           cf-org: cf-org-name
           cf-space: cf-spac-name
+          cf-group: default
           cf-region: us-south
+          cf-api: https://api.us-south.cf.cloud.ibm.com
           cf-app: cf-app-name
           cf-manifest: manifest.yml
           deploy-dir: packages/my-awesome-package

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
           cf-space: cf-spac-name
           cf-group: default
           cf-region: us-south
-          cf-api: https://api.us-south.cf.cloud.ibm.com
+          cf-api: https://cloud.ibm.com
           cf-app: cf-app-name
           cf-manifest: manifest.yml
           deploy-dir: packages/my-awesome-package

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,17 @@ inputs:
   cf-space:
     description: 'CloudFoundry space'
     required: true
+  cf-group:
+    description: 'Resource Group Name or ID'
+    required: false
+  cf-api:
+    description: 'CloudFoundry API endpoint'
+    required: false
+    default: 'https://api.us-south.cf.cloud.ibm.com'
   cf-region:
     description: 'CloudFoundry region'
     required: false
+    default: 'us-south'
   cf-app:
     description: 'CloudFoundry application name'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   cf-api:
     description: 'CloudFoundry API endpoint'
     required: false
-    default: 'https://api.us-south.cf.cloud.ibm.com'
+    default: 'https://cloud.ibm.com'
   cf-region:
     description: 'CloudFoundry region'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1571,26 +1571,12 @@ async function login() {
     const cloudAPIKey = getInput('cloud-api-key');
     const org = getInput('cf-org');
     const space = getInput('cf-space');
+    const group = getInput('cf-group');
     const region = getInput('cf-region');
+    const api = getInput('cf-api');
     setSecret(cloudAPIKey);
-    await exec(
-      'ibmcloud',
-      [
-        'login',
-        '-a',
-        'https://cloud.ibm.com',
-        '-u',
-        'apikey',
-        '-p',
-        cloudAPIKey,
-        '-o',
-        org,
-        '-s',
-        space,
-        ...(!region ? [] : ['-r', region]),
-      ],
-      execOptions
-    );
+    await exec('ibmcloud', ['login', '-a', api, '-u', 'apikey', '-p', cloudAPIKey, '-r', region], execOptions);
+    await exec('ibmcloud', ['target', '-o', org, '-s', space, ...(!group ? [] : ['-g', group])], execOptions);
   } catch (error) {
     setFailed(`Logging into IBM Cloud failed: ${error.stack}`);
     throw error;
@@ -4666,7 +4652,7 @@ async function install() {
   try {
     const cliPath = await downloadTool('https://clis.cloud.ibm.com/install/linux');
     await exec('bash', [cliPath], execOptions);
-    await run('ibmcloud cf install', execOptions);
+    await run('ibmcloud cf install -v 6.51.0 --force', execOptions);
   } catch (error) {
     setFailed(`Error installing IBM Cloud CLI: ${error.stack}`);
     throw error;

--- a/lib/install.js
+++ b/lib/install.js
@@ -20,7 +20,7 @@ async function install() {
   try {
     const cliPath = await downloadTool('https://clis.cloud.ibm.com/install/linux');
     await exec('bash', [cliPath], execOptions);
-    await run('ibmcloud cf install', execOptions);
+    await run('ibmcloud cf install -v 6.51.0 --force', execOptions);
   } catch (error) {
     setFailed(`Error installing IBM Cloud CLI: ${error.stack}`);
     throw error;

--- a/lib/login.js
+++ b/lib/login.js
@@ -16,26 +16,12 @@ async function login() {
     const cloudAPIKey = getInput('cloud-api-key');
     const org = getInput('cf-org');
     const space = getInput('cf-space');
+    const group = getInput('cf-group');
     const region = getInput('cf-region');
+    const api = getInput('cf-api');
     setSecret(cloudAPIKey);
-    await exec(
-      'ibmcloud',
-      [
-        'login',
-        '-a',
-        'https://cloud.ibm.com',
-        '-u',
-        'apikey',
-        '-p',
-        cloudAPIKey,
-        '-o',
-        org,
-        '-s',
-        space,
-        ...(!region ? [] : ['-r', region]),
-      ],
-      execOptions
-    );
+    await exec('ibmcloud', ['login', '-a', api, '-u', 'apikey', '-p', cloudAPIKey, '-r', region], execOptions);
+    await exec('ibmcloud', ['target', '-o', org, '-s', space, ...(!group ? [] : ['-g', group])], execOptions);
   } catch (error) {
     setFailed(`Logging into IBM Cloud failed: ${error.stack}`);
     throw error;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:scripts": "eslint --ext .js .",
     "lint:license:staged": "tools/check-license.js -w",
     "lint:scripts:staged": "eslint",
-    "test": "jest"
+    "test": "jest",
+    "stage-built": "git add dist/index.js dist/logout.js"
   },
   "license": "Apache-2",
   "dependencies": {
@@ -45,6 +46,7 @@
     "jest": "^26.1.0",
     "jest-circus": "^26.1.0",
     "lint-staged": "^10.2.0",
+    "pre-commit": "^1.2.0",
     "prettier": "^2.0.0",
     "through2": "^4.0.0"
   },
@@ -79,6 +81,7 @@
       "git add"
     ]
   },
+  "pre-commit": ["build", "stage-built"],
   "prettier": {
     "jsxBracketSameLine": true,
     "printWidth": 130,

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -23,7 +23,7 @@ describe('Installing IBM Cloud CLI', () => {
     await install();
     expect(downloadTool).toHaveBeenCalledWith('https://clis.cloud.ibm.com/install/linux');
     expect(exec).toHaveBeenNthCalledWith(1, 'bash', ['/path/to/ibmcloud/cli'], execOptions);
-    expect(exec).toHaveBeenNthCalledWith(2, 'ibmcloud', ['cf', 'install'], execOptions);
+    expect(exec).toHaveBeenNthCalledWith(2, 'ibmcloud', ['cf', 'install', '-v', '6.51.0', '--force'], execOptions);
   });
 
   it('handles error downloading IBM Cloud CLI', async () => {

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -24,24 +24,43 @@ describe('Installing IBM Cloud CLI', () => {
           'cloud-api-key': 'cloud-api-key-foo',
           'cf-org': 'cf-org-foo',
           'cf-space': 'cf-space-foo',
+          'cf-region': 'cf-region-foo',
+          'cf-api': 'https://api.us-south.cf.cloud.ibm.com',
         }[name])
     );
     await login();
-    expect(exec).toHaveBeenCalledWith(
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
       'ibmcloud',
-      [
-        'login',
-        '-a',
-        'https://cloud.ibm.com',
-        '-u',
-        'apikey',
-        '-p',
-        'cloud-api-key-foo',
-        '-o',
-        'cf-org-foo',
-        '-s',
-        'cf-space-foo',
-      ],
+      ['login', '-a', 'https://api.us-south.cf.cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
+      execOptions
+    );
+    expect(exec).toHaveBeenNthCalledWith(2, 'ibmcloud', ['target', '-o', 'cf-org-foo', '-s', 'cf-space-foo'], execOptions);
+  });
+
+  it('runs the right set of commands with CF group specified', async () => {
+    getInput.mockImplementation(
+      (name) =>
+        ({
+          'cloud-api-key': 'cloud-api-key-foo',
+          'cf-org': 'cf-org-foo',
+          'cf-space': 'cf-space-foo',
+          'cf-group': 'cf-group-foo',
+          'cf-region': 'cf-region-foo',
+          'cf-api': 'https://api.us-south.cf.cloud.ibm.com',
+        }[name])
+    );
+    await login();
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
+      'ibmcloud',
+      ['login', '-a', 'https://api.us-south.cf.cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
+      execOptions
+    );
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      'ibmcloud',
+      ['target', '-o', 'cf-org-foo', '-s', 'cf-space-foo', '-g', 'cf-group-foo'],
       execOptions
     );
   });
@@ -54,28 +73,17 @@ describe('Installing IBM Cloud CLI', () => {
           'cf-org': 'cf-org-foo',
           'cf-space': 'cf-space-foo',
           'cf-region': 'cf-region-foo',
+          'cf-api': 'https://api.us-south.cf.cloud.ibm.com',
         }[name])
     );
     await login();
-    expect(exec).toHaveBeenCalledWith(
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
       'ibmcloud',
-      [
-        'login',
-        '-a',
-        'https://cloud.ibm.com',
-        '-u',
-        'apikey',
-        '-p',
-        'cloud-api-key-foo',
-        '-o',
-        'cf-org-foo',
-        '-s',
-        'cf-space-foo',
-        '-r',
-        'cf-region-foo',
-      ],
+      ['login', '-a', 'https://api.us-south.cf.cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
       execOptions
     );
+    expect(exec).toHaveBeenNthCalledWith(2, 'ibmcloud', ['target', '-o', 'cf-org-foo', '-s', 'cf-space-foo'], execOptions);
   });
 
   it('handles error executing command', async () => {

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -25,14 +25,14 @@ describe('Installing IBM Cloud CLI', () => {
           'cf-org': 'cf-org-foo',
           'cf-space': 'cf-space-foo',
           'cf-region': 'cf-region-foo',
-          'cf-api': 'https://api.us-south.cf.cloud.ibm.com',
+          'cf-api': 'https://cloud.ibm.com',
         }[name])
     );
     await login();
     expect(exec).toHaveBeenNthCalledWith(
       1,
       'ibmcloud',
-      ['login', '-a', 'https://api.us-south.cf.cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
+      ['login', '-a', 'https://cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
       execOptions
     );
     expect(exec).toHaveBeenNthCalledWith(2, 'ibmcloud', ['target', '-o', 'cf-org-foo', '-s', 'cf-space-foo'], execOptions);
@@ -47,14 +47,14 @@ describe('Installing IBM Cloud CLI', () => {
           'cf-space': 'cf-space-foo',
           'cf-group': 'cf-group-foo',
           'cf-region': 'cf-region-foo',
-          'cf-api': 'https://api.us-south.cf.cloud.ibm.com',
+          'cf-api': 'https://cloud.ibm.com',
         }[name])
     );
     await login();
     expect(exec).toHaveBeenNthCalledWith(
       1,
       'ibmcloud',
-      ['login', '-a', 'https://api.us-south.cf.cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
+      ['login', '-a', 'https://cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
       execOptions
     );
     expect(exec).toHaveBeenNthCalledWith(
@@ -73,14 +73,14 @@ describe('Installing IBM Cloud CLI', () => {
           'cf-org': 'cf-org-foo',
           'cf-space': 'cf-space-foo',
           'cf-region': 'cf-region-foo',
-          'cf-api': 'https://api.us-south.cf.cloud.ibm.com',
+          'cf-api': 'https://cloud.ibm.com',
         }[name])
     );
     await login();
     expect(exec).toHaveBeenNthCalledWith(
       1,
       'ibmcloud',
-      ['login', '-a', 'https://api.us-south.cf.cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
+      ['login', '-a', 'https://cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
       execOptions
     );
     expect(exec).toHaveBeenNthCalledWith(2, 'ibmcloud', ['target', '-o', 'cf-org-foo', '-s', 'cf-space-foo'], execOptions);


### PR DESCRIPTION
This change locks down the CF CLI version to `6.51.0`, due to cloudfoundry/cli#2033.

Adds support for the following options:

* `cf-api` The CloudFoundry API entrypoint
* `cf-group`: The resource group name