### PR TITLE
fix(login): use cf-api parameter in correct place

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
           cf-space: cf-spac-name
           cf-group: default
           cf-region: us-south
-          cf-api: https://cloud.ibm.com
+          cf-api: https://api.us-south.cf.cloud.ibm.com
           cf-app: cf-app-name
           cf-manifest: manifest.yml
           deploy-dir: packages/my-awesome-package

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ inputs:
   cf-api:
     description: 'CloudFoundry API endpoint'
     required: false
-    default: 'https://cloud.ibm.com'
   cf-region:
     description: 'CloudFoundry region'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1575,8 +1575,16 @@ async function login() {
     const region = getInput('cf-region');
     const api = getInput('cf-api');
     setSecret(cloudAPIKey);
-    await exec('ibmcloud', ['login', '-a', api, '-u', 'apikey', '-p', cloudAPIKey, '-r', region], execOptions);
-    await exec('ibmcloud', ['target', '-o', org, '-s', space, ...(!group ? [] : ['-g', group])], execOptions);
+    await exec(
+      'ibmcloud',
+      ['login', '-a', 'https://cloud.ibm.com', '-u', 'apikey', '-p', cloudAPIKey, '-r', region],
+      execOptions
+    );
+    await exec(
+      'ibmcloud',
+      ['target', '-o', org, '-s', space, ...(!group ? [] : ['-g', group]), ...(!api ? [] : ['--cf-api', api])],
+      execOptions
+    );
   } catch (error) {
     setFailed(`Logging into IBM Cloud failed: ${error.stack}`);
     throw error;

--- a/lib/login.js
+++ b/lib/login.js
@@ -20,8 +20,16 @@ async function login() {
     const region = getInput('cf-region');
     const api = getInput('cf-api');
     setSecret(cloudAPIKey);
-    await exec('ibmcloud', ['login', '-a', api, '-u', 'apikey', '-p', cloudAPIKey, '-r', region], execOptions);
-    await exec('ibmcloud', ['target', '-o', org, '-s', space, ...(!group ? [] : ['-g', group])], execOptions);
+    await exec(
+      'ibmcloud',
+      ['login', '-a', 'https://cloud.ibm.com', '-u', 'apikey', '-p', cloudAPIKey, '-r', region],
+      execOptions
+    );
+    await exec(
+      'ibmcloud',
+      ['target', '-o', org, '-s', space, ...(!group ? [] : ['-g', group]), ...(!api ? [] : ['--cf-api', api])],
+      execOptions
+    );
   } catch (error) {
     setFailed(`Logging into IBM Cloud failed: ${error.stack}`);
     throw error;

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -25,7 +25,6 @@ describe('Installing IBM Cloud CLI', () => {
           'cf-org': 'cf-org-foo',
           'cf-space': 'cf-space-foo',
           'cf-region': 'cf-region-foo',
-          'cf-api': 'https://cloud.ibm.com',
         }[name])
     );
     await login();
@@ -47,7 +46,6 @@ describe('Installing IBM Cloud CLI', () => {
           'cf-space': 'cf-space-foo',
           'cf-group': 'cf-group-foo',
           'cf-region': 'cf-region-foo',
-          'cf-api': 'https://cloud.ibm.com',
         }[name])
     );
     await login();
@@ -65,7 +63,7 @@ describe('Installing IBM Cloud CLI', () => {
     );
   });
 
-  it('runs the right set of commands with CF region specified', async () => {
+  it('runs the right set of commands with CF API endpoint specified', async () => {
     getInput.mockImplementation(
       (name) =>
         ({
@@ -73,7 +71,7 @@ describe('Installing IBM Cloud CLI', () => {
           'cf-org': 'cf-org-foo',
           'cf-space': 'cf-space-foo',
           'cf-region': 'cf-region-foo',
-          'cf-api': 'https://cloud.ibm.com',
+          'cf-api': 'https://api.us-south.cf.cloud.ibm.com',
         }[name])
     );
     await login();
@@ -83,7 +81,12 @@ describe('Installing IBM Cloud CLI', () => {
       ['login', '-a', 'https://cloud.ibm.com', '-u', 'apikey', '-p', 'cloud-api-key-foo', '-r', 'cf-region-foo'],
       execOptions
     );
-    expect(exec).toHaveBeenNthCalledWith(2, 'ibmcloud', ['target', '-o', 'cf-org-foo', '-s', 'cf-space-foo'], execOptions);
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      'ibmcloud',
+      ['target', '-o', 'cf-org-foo', '-s', 'cf-space-foo', '--cf-api', 'https://api.us-south.cf.cloud.ibm.com'],
+      execOptions
+    );
   });
 
   it('handles error executing command', async () => {


### PR DESCRIPTION
This change makes `cf-api` input arg is used for CF API endpoint (that is set via `ibmcloud target --cf-api`) instead of IBM Cloud API endpoint (that is set via `ibmcloud login -a`), and removes its default value (as it works without being set).

#2 was the first attempt to introduce `cf-api` arg, and according to @jeffchew, it was intended to be CF API endpoint.

At the time of creating this change, CF CLI version lockdown seems still needed, even if we do `ibmcloud target --cf-api`.